### PR TITLE
Add explicit CRLF to IMAP commands

### DIFF
--- a/Get-IMAPAccessToken.ps1
+++ b/Get-IMAPAccessToken.ps1
@@ -178,6 +178,7 @@ $Port = '993'
     $SSLstreamReader = new-object System.IO.StreamReader($sslStream)
     $SSLstreamWriter = new-object System.IO.StreamWriter($sslStream)
     $SSLstreamWriter.AutoFlush = $true
+    $SSLstreamWriter.Newline = "`r`n"
     $SSLstreamReader.ReadLine()
 
     Write-Host "Authenticate using XOAuth2." -ForegroundColor DarkGreen


### PR DESCRIPTION
On Windows, the current version of the script works as-is for me when using client credentials auth flow.

On Ubuntu (and presumably similar distros) I encountered "hanging" commands.

The fix was to explicitly emit CRLF EOL when writing to the stream writer.

This allowed the script to execute properly on Windows and Ubuntu with the `MSAL.PS` module installed.

Tested using PowerShell v7.3.0.

References:

- https://stackoverflow.com/a/26802133/903870
- https://datatracker.ietf.org/doc/html/rfc9051

Specifically:

> All interactions transmitted by client and server are in
> the form of lines, that is, strings that end with a CRLF.

refs https://github.com/DanijelkMSFT/ThisandThat/issues/2